### PR TITLE
Add *.mac Compilation Support and Additional Routine Compilation Warnings

### DIFF
--- a/cos.js
+++ b/cos.js
@@ -73,23 +73,49 @@ const activate = context => {
         const fileBody = openedDoc.getText()
         const isClass = /\.cls$/i.test( fileName )
         const content = fileBody.split( /\r?\n/g )
+	    const matchingFileName = ( fileName.match(/[^\\\/]+$/) || [] )[ 0 ] || ''
+        const matchingName = matchingFileName.replace( /\.[^.]+$/, '' )
 
         if ( isClass ) {
+
             // Caché class files can be placed hierarchically (e.g. /src/Package/Class.cls),
             // so we pick the class name from the class definition itself
-            cacheDocName = (fileBody.replace( /\/\/[^\r\n]*\r?\n/g, '' ).match( /Class ([^\s]+)/i ) || [])[ 1 ] || ""
+            cacheDocName = (fileBody.replace( /\/\/[^\r\n]*\r?\n/g, '' ).match( /Class ([^\s]+)/i ) || [])[ 1 ] || ''
             const nameParts = cacheDocName.split( /\./g ).filter(s => !!s)
             if ( nameParts.length < 2 )
                 return log( `Unable to detect class name in source code of ${ fileName }.\n`
                     + `Is it a valid Caché ObjectScript class?` )
-            const matchingFileName = ( fileName.match(/[^\\\/]+$/) || [] )[ 0 ]
-            if ( ( cacheDocName.toLowerCase() + '.cls' ).indexOf(matchingFileName.toLowerCase()) === -1 )
-                return log( `You tried to compile class named "${ cacheDocName }" in file "${ matchingFileName }".\n`
-                    + `Did you forget to rename the file/class to correspond to each other?` )
+            if ( ( cacheDocName.toLowerCase() + '.cls' ).indexOf( matchingFileName.toLowerCase() ) === -1 )
+                return log(
+                    `You tried to compile class named "${ cacheDocName }" in file "${ matchingFileName }".\n`
+                    + `Did you forget to rename the file/class to correspond to each other?`
+                )
             cacheDocName += '.cls'
+
         } else {
-            // routine: cacheDocName = actual filename
-            cacheDocName = ( fileName.match( /[\\\/]([^\\\/]+)$/ ) || [] )[ 1 ] || ""
+
+            // routine: routine name must be declared in a routine
+            const cleanup = fileBody.replace( /\/\/[^\r\n]*\r?\n/g, '' )
+	        cacheDocName = ( cleanup.match( /routine ([^\s]+)/i ) || [] )[ 1 ] || ''
+	        if ( !cacheDocName )
+		        return log(
+		            `Unable to detect routine name in source code of ${ matchingFileName }.\n`
+			        + `Is it a valid Caché ObjectScript routine? Did you forget to define a routine`
+                    + ` name in the file on the first line? Routine code example: \n\n`
+                    + `ROUTINE ${ matchingName } [Type=MAC]`
+                    + `\n    write "routine code here"\n    quit`
+                )
+            const rtnType = ( cleanup.match( /routine\s+[^\s]+\s+\[.*type=([a-z]{3,})/i ) || [] )[ 1 ] || 'MAC'
+            if ( ( ( cacheDocName + '.' + rtnType ).toLowerCase() ).indexOf( matchingFileName.toLowerCase() ) === -1 )
+                return log(
+	                `You tried to compile routine named "${ cacheDocName }" (.${ rtnType }) in file "${ 
+                        matchingFileName }".\nDid you forget to rename the file/routine to correspond to each other? `
+                    + `Routine code example: \n\n`
+                    + `ROUTINE ${ matchingName } [Type=${ rtnType }]`
+                    + `\n    write "routine code here"\n    quit`
+                )
+            cacheDocName += '.' + rtnType
+
         }
 
         const anyErrors = (err, res, keyword) => {

--- a/cos.js
+++ b/cos.js
@@ -73,7 +73,7 @@ const activate = context => {
         const fileBody = openedDoc.getText()
         const isClass = /\.cls$/i.test( fileName )
         const content = fileBody.split( /\r?\n/g )
-	    const matchingFileName = ( fileName.match(/[^\\\/]+$/) || [] )[ 0 ] || ''
+        const matchingFileName = ( fileName.match(/[^\\\/]+$/) || [] )[ 0 ] || ''
         const matchingName = matchingFileName.replace( /\.[^.]+$/, '' )
 
         if ( isClass ) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-cos",
   "displayName": "Caché ObjectScript",
   "description": "Caché ObjectScript language support for Visual Studio Code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "icon": "images/logo.png",
   "categories": [
     "Languages",
@@ -14,7 +14,10 @@
   },
   "publisher": "doublefint",
   "contributors": [
-    { "name": "Nikita Savchenko", "email": "me@nikita.tk" }
+    {
+      "name": "Nikita Savchenko",
+      "email": "me@nikita.tk"
+    }
   ],
   "engines": {
     "vscode": "^1.5.0"
@@ -72,10 +75,10 @@
     ],
     "keybindings": [
       {
-				"command": "cos.compile",
-				"key": "Ctrl+F7",
-				"mac": "Cmd+F7"
-			}
+        "command": "cos.compile",
+        "key": "Ctrl+F7",
+        "mac": "Cmd+F7"
+      }
     ],
     "configuration": {
       "title": "cos",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-cos",
   "displayName": "Caché ObjectScript",
   "description": "Caché ObjectScript language support for Visual Studio Code",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "icon": "images/logo.png",
   "categories": [
     "Languages",
@@ -34,7 +34,8 @@
           "COS"
         ],
         "extensions": [
-          ".cls"
+          ".cls",
+          ".mac"
         ],
         "configuration": "./language-configuration.json"
       },

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,8 @@ Configure connection
 To be able to use many plugin features, you need to configure the connection to Caché server first.
 
 - Find a 'cos.conn' section in workspace settings (File - Preferences - Settings)
-- change settings according to your Caché instance and reload VSCode ( as temporary solution ) 
+- Change settings according to your Caché instance and reload VSCode ( as temporary solution )
+- You will see Caché-related output in "Output" while switched to "cos" channel (right drop-down menu on top of the output window) 
 
 Features
 --------


### PR DESCRIPTION
Привет Олег,

Сделал ещё несколько изменений для комфортной работы:
1. Добавил `*.mac` в список расширений Caché ObjectScript. Поскольку грамматика подсвечивает код по регулярным выражением, существующая отлично подходит и для рутин на первое время. Также, что более важно, теперь mac можно скомпилировать прямо из VSCode.
2. Добавил проверки и подсказки в рутины, как и ранее для классов. Например, если назвать файл `ThisIsTest.inc`, а в файле будет

```asm
Routine ThisIsTest [Type=MAC]

ThisIsTest
    write 1
    quit
```

Вылезет ошибка:

```txt
You tried to compile routine named "ThisIsTest" (.MAC) in file "ThisIsTest.inc".
Did you forget to rename the file/routine to correspond to each other? Routine code example: 

ROUTINE ThisIsTest [Type=MAC]
    write "routine code here"
    quit
```

Это потому что несколько раз сам сталкивался с проблемами при копировании классов - это уведомление их предотвратит. Там немного более замысловатая проверка, нежели просто на соответствие имя файла и тому, что написано в нём. Например, если расположить рутину/класс в иерархии директорий вот так: `/src/MyPackage/MySubPackage/MyClass.cls` с классом

```cls
Class MyPackage.MySubPackage.MyClass {
// ...
}
```

То всё тоже получится. Я так располагаю файлы классов в своих проектах, по директориям - удобно.