### PR TITLE
Allow HTTPS Connections to Caché

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-cos",
   "displayName": "Caché ObjectScript",
   "description": "Caché ObjectScript language support for Visual Studio Code",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "icon": "images/logo.png",
   "categories": [
     "Languages",
@@ -96,7 +96,8 @@
             "password": "SYS",
             "path": "/api/atelier/",
             "version": "v1",
-            "ns": "SAMPLES"
+            "ns": "SAMPLES",
+            "https": false
           }
         }
       }
@@ -106,6 +107,6 @@
     "vscode": "^1.0.3"
   },
   "dependencies": {
-    "cos-api4node": "^2.0.0"
+    "cos-api4node": "^2.1.0"
   }
 }


### PR DESCRIPTION
I've pulled the latest version of `cos-api4node`, where I added a HTTPS switch. Now it should be possible to connect to Caché via HTTPS.

Should resolve #3 :)