### PR TITLE
Added option to remove the storage xml from the source.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-cos",
-  "displayName": "Caché ObjectScript",
-  "description": "Caché ObjectScript language support for Visual Studio Code",
+  "displayName": "Cachï¿½ ObjectScript",
+  "description": "Cachï¿½ ObjectScript language support for Visual Studio Code",
   "version": "0.6.1",
   "icon": "images/logo.png",
   "categories": [
@@ -231,6 +231,16 @@
           "type": "boolean",
           "default": true,
           "description": "Show or hide the Explorer."
+        },
+        "cos.export.noStorage": {
+          "description": "Strip the storage xml on export.  (Useful for multiple systems)",
+          "type": "boolean",
+          "default": false
+        },
+        "cos.export.dontExportIfNoChanges": {
+          "description": "Don't update the local file on export if the content is identical to the server code",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-cos",
-  "displayName": "Cach� ObjectScript",
-  "description": "Cach� ObjectScript language support for Visual Studio Code",
+  "displayName": "Caché ObjectScript",
+  "description": "Caché ObjectScript language support for Visual Studio Code",
   "version": "0.6.1",
   "icon": "images/logo.png",
   "categories": [


### PR DESCRIPTION
There are situations where we may want to compile code on a server where the storage properties order is different to where we exported the source files from and this will cause issues with the fields returning incorrect data.  I thought it would be useful to add an option to remove the storage from the code to avoid the issue.

I have also added an option to not update the local file if the server and the local file are the same.  Mainly so we can see what has changed without vscode reporting that everything has changed.